### PR TITLE
Added return home button in error.tsx

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -5,6 +5,8 @@
 
 import { Button } from "@/components/ui/Button";
 import Image from "next/image";
+import Link from "next/link";
+import { Home } from "lucide-react";
 
 export default function GlobalError({
   error: _error,
@@ -30,14 +32,23 @@ export default function GlobalError({
         </p>
 
         {/* Кнопка "reset" пытается перезагрузить страницу */}
-        <Button
-          size="lg"
-          className="mt-8 bg-[#1e3a8a] text-white hover:bg-[#1e3a8a]/90 shadow-md"
-          onClick={() => reset()}
-        >
-          Попробовать снова
-        </Button>
-      </div>
+        <div className="mt-8 flex flex-col sm:flex-row gap-3">
+          <Button
+            size="lg"
+            className="bg-[#1e3a8a] text-white hover:bg-[#1e3a8a]/90 shadow-md"
+            onClick={() => reset()}
+          >
+            Попробовать снова
+          </Button>
+
+          <Button size="lg" variant="outline" asChild>
+            <Link href="/">
+              <Home size={20} className="mr-2" />
+              Вернуться домой
+            </Link>
+          </Button>
+        </div>
+        </div>
       <div className="flex-shrink-0 mb-8 lg:mb-0">
         <Image
           src="/500.webp"


### PR DESCRIPTION
## Summary

Fix #69 
Adds a secondary "Return Home" action to the global error page so users can navigate back to the homepage when retrying does not resolve the error.

## Changes

* Added a "Return Home" button linking to `/`
* Added the `Home` icon from `lucide-react`
* Used the existing `outline` button variant to distinguish it from the primary retry action
* Updated the button layout to be responsive:
* Vertical stack on mobile devices
* Horizontal layout on larger screens